### PR TITLE
Add the ability to run the server as a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ WORKDIR /bot
 
 ADD . /bot
 
-ENV CONFIG_FILE /data/config.json
-
 RUN mkdir /data
 RUN npm install
 
-CMD node ./index.js -configFile $CONFIG_FILE
+# /data/config comes from a file mount, replacing the default blank one in the container
+CMD cp /data/config.json /bot/config.json && node ./index.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12-stretch-slim
+
+WORKDIR /bot
+
+ADD . /bot
+
+ENV CONFIG_FILE /bot/config.json
+
+RUN npm install
+
+CMD node ./index.js -configFile $CONFIG_FILE

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:12-stretch-slim
 
 WORKDIR /bot
 
-ADD . /bot
+COPY . /bot
 
 RUN mkdir /data
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ WORKDIR /bot
 
 ADD . /bot
 
-ENV CONFIG_FILE /bot/config.json
+ENV CONFIG_FILE /data/config.json
 
+RUN mkdir /data
 RUN npm install
 
 CMD node ./index.js -configFile $CONFIG_FILE

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ First, follow the [NodeJS install instructions found here](https://nodejs.org/en
 
 If running the bot on the same network as the Raspberry Pi, you will likely need to enter the computer's internal IP. Open a commant prompt on the system that the server is running on and type `ipconfig`. Look for the field labeled 'IPv4 address' and copy the IP next to it (the IP should start with `196.168`). Then, copy this IP into the config.json under 'ip'. If this does not work, consider forwarding your telnet port (make sure the password is secure) and using the network's external IP.
 
+## Using Docker
+You can use a docker container to run the bot. 
+`docker run --restart="always" -v PATH_TO_CONFIG:/data thaelah/7days-to-die-discord`
+
+Note: If you are using docker to run the actual 7 days to die server, consider making a docker network to share ports.
+
+
 ## Setting up the bot
 1. Open a terminal on your system.
 2. Install Node.js and NPM. Install build tools if instructed. [[How to install via package manager]](https://nodejs.org/en/download/package-manager/). **Skip this step if installing to an Android or Raspberry Pi device.**

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ You can use a docker container to run the bot.
 
 You have to replace PATH_TO_CONFIG with a directory containing your version of the [./config.json] file.
 
-Note: If you are using docker to run the actual 7 days to die server, consider making a docker network to share ports.
+Networking: 
+If you are using docker to run the actual 7 days to die server, consider making a docker network to share ports.
+If you are running the server locally, you should use the --net="host" option or otherwise forward the telnet port into the container.
 
 
 ## Setting up the bot

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ If running the bot on the same network as the Raspberry Pi, you will likely need
 
 ## Using Docker
 You can use a docker container to run the bot. 
-`docker run --restart="always" -v PATH_TO_CONFIG:/data thaelah/7days-to-die-discord`
+`docker run --restart="always" -v PATH_TO_CONFIG:/data -d thaelah/7days-to-die-discord`
+
+You have to replace PATH_TO_CONFIG with a directory containing your version of the [./config.json] file.
 
 Note: If you are using docker to run the actual 7 days to die server, consider making a docker network to share ports.
 


### PR DESCRIPTION
This Dockerfile will build a docker image as an easy way to manage running this server.

Things a user will have to think about if they want to go this route:
- Mounting the config file as a directory
- How do they want to restart the container if it fails
- Networking (connectivity to other containers//host)

I've tried to add this to the README to make it easy.

If you accept this PR, I suggest making an account at hub.docker.com and linking your github repository to it. You can setup CI/CD there so that if you ever update master, the docker image is automatically run. If you do that, we should change the readme to match your docker account's image instead of mine.