### PR TITLE
Fix double post on modded servers

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -22,6 +22,7 @@
   "disable-status-updates": false,
   "disable-version-check": false,
   "hide-prefix": false,
+  "server-is-modded": false,
   "horde-frequency": "7",
   "log-console": false,
   "log-messages": false,

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ var argv = minimist(process.argv.slice(2), {string: ["channel","port"]});
 
 // cache previous Message to check for double messages
 var previousMsg;
+var reg = /\[.*\]\(.*\)\[-\]\[[a-fA-F\d]{3,6}\]([^[]+)\[-](: .+)/;
 
 // This is a simple check to see if we're using arguments or the config file.
 // If the user is using arguments, config.json is ignored.
@@ -146,7 +147,24 @@ const configPrivate = {
 new DishordeInitializer(pjson, config, configPrivate);
 
 ////// # Functions # //////
+function ServerToolsRegex(msg) {
+  // Check for ServerTools color code prefix and remove it to
+  // align with normal messages
+  try {
+    let newMsg = msg.match(reg);
+    msg = newMsg[1] + newMsg[2];
+    console.log(`regex matched, ${newMsg}`);
+  }
+  catch {
+    // regex did not match
+    console.log(`regex did not match`);
+  }
+  return msg;
+}
+
 function checkForDoubleMsg(msg) {
+  // Check for ServerTools
+  msg = ServerToolsRegex(msg);
   if(msg == previousMsg) {
     // Message was the same, so return nothing
     msg = "";
@@ -166,7 +184,9 @@ function sanitizeMsgFromGame(msg) {
     msg = msg.replace(/https:\/\//g, "https\\://");
     msg = msg.replace(/http:\/\//g, "http\\://");
   }
-  msg = checkForDoubleMsg(msg)
+  if(config["server-is-modded"]) {
+    msg = checkForDoubleMsg(msg);
+  }
   return msg;
 }
 


### PR DESCRIPTION
This is a potential fix for the issue mentioned in 
https://github.com/LakeYS/Dishorde/issues/141
and
https://github.com/LakeYS/Dishorde/issues/138
where on a modded server messages that are sent appear twice on the Discord channel. I added a storage variable and a function to check for the doubled message. 
To not end up in a loop, the storage Variable will be cleared after it was detected it is a duplicate.

This has one downside though: on a non-modded server if someone posts the same message twice, the second message would not be sent to the Discord channel (the third time will work again, fourth not, ... and so on). But i don't think the impact is too negative. I don't know enough about the message system of 7days to counter that.

It was tested and confirmed working by the User DarqRain on the 7daystodie discord server.

Thank you LakeYS for the easy to read code and the good comments :)