### PR TITLE
Publish container image on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!package.json
+!package-lock.json
+!index.js
+!lib

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+name: Release Container Image
+
+on:
+    release:
+        types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: lakeys/dishorde
+  PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+    build-and-publish:
+        name: Build and Publish Container Image
+        runs-on: ubuntu-latest
+
+        steps:
+        - name: Checkout code
+          uses: actions/checkout@v3
+
+        - name: Log in to GitHub Container Registry
+          uses: docker/login-action@v2
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v2
+          with:
+            platforms: ${{ env.PLATFORMS }}
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
+
+        - name: Extract metadata (tags, labels) for Docker
+          id: meta
+          uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+          with:
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            tags: |
+              type=semver,pattern={{version}}
+              type=semver,pattern={{major}}.{{minor}}
+              type=semver,pattern={{major}}
+
+        - name: Build and push Container image
+          uses: docker/build-push-action@v4
+          with:
+            context: .
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            platforms: ${{ env.PLATFORMS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# 22-alpine
+FROM docker.io/node@sha256:9bef0ef1e268f60627da9ba7d7605e8831d5b56ad07487d24d1aa386336d1944 as build
+
+WORKDIR /app
+COPY package.json .
+COPY package-lock.json .
+
+RUN npm install
+
+# 22-alpine
+FROM docker.io/node@sha256:9bef0ef1e268f60627da9ba7d7605e8831d5b56ad07487d24d1aa386336d1944
+
+WORKDIR /app
+COPY . .
+COPY --from=build /app/node_modules ./node_modules
+
+CMD ["node", "index.js"]

--- a/README.md
+++ b/README.md
@@ -117,3 +117,38 @@ Once you complete all of this, you will be able to run the bot by executing run.
 `Connected to game. Connected to 1 Discord Servers.`
 
 To set the channel for your server's chat, open Discord and type `7d!setchannel #yourchannel` in your server. If the setchannel command doesn't work, try [setting it manually](https://github.com/LakeYS/Dishorde/wiki/Setting-up-the-channel-manually). Once complete, the bot should be all set!
+
+
+# How to Install - Docker
+
+## Creating the bot account
+1. Log in to the [Discord Developer Portal](https://discord.com/developers) in a browser and click "Create an application". Name the bot anything you'd like. Write down the application ID as you'll need it for later.
+2. On the left hand side, click "Bot". Now click the "Add Bot" button to create your bot. Once created, you can set an avatar for your bot if desired.
+3. Under "Privileged Gateway Intents", locate the "Message Content Intent" switch and turn this on. ***Important**! If you do not turn this on, the bot will not be able to see your messages or commands.*
+4. Under "Authorization Flow", locate the "Public Bot" switch and turn this off. ***Important!** If you do not turn this off, anyone can create a link to invite your server's bot to their own server.*
+5. Click "Save Changes" to confirm.
+6. Back towards the top, click the "Reset Token" button and reset the token. When done, the button will be replaced by a long set of letters and numbers. This is your bot's 'token'--like a password for your bot's account. You'll need both this and the Client ID number later. Copy them both somewhere safe or keep the tab open. ***Note!** Once you close the page, you will not be able to retrieve your bot's token without resetting it.*
+7. Copy the URL below into your browser and replace "APP_ID" with your application ID number. Hit enter and select the desired Discord server. Once this is done, the bot will show up in your server!
+
+`https://discord.com/oauth2/authorize?client_id=APP_ID&scope=bot`
+
+## Setting up the bot
+1. Install Docker.
+2. Now you'll need to edit your server's config xml file. If you're using the Steam dedicated server, it should be located in `C:\Program Files (x86)\Steam\steamapps\common\7 Days to Die Dedicated Server`.
+3. Open serverconfig.xml in a text editor (Right click and select 'Edit' to open it in Nodepad) and find "TelnetEnabled". Set it to true. Make sure TelnetPort is 8081 (or use the "port" argument in config.json). Set a telnet password.
+4. Download the [config.json.example](https://github.com/LakeYS/Dishorde/blob/master/config.example.json) file to config.json. Right click this file and click "Edit".
+5. Find "changeme" and replace it with your server's Telnet password. Replace "your_token_here" with the Discord token from earlier. If running the bot on a different network from the server, add `--ip=[your server's external ip]` (May require port forwarding if using an external IP. Make sure your Telnet password is secure.)
+6. Create a `docker-compose.yaml` file in the same directory as your `config.json` with the following contents:
+
+```yaml
+services:
+  dishorde:
+    image: ghcr.io/lakeys/dishorde:2
+    # If you're running 7 days to die in another container you may want to setup a private network
+    # https://docs.docker.com/reference/compose-file/services/#networks
+    network_mode: "host"
+    volumes:
+      - ./config.json:/app/config.json
+```
+
+7. Run `docker compose up` to start the bot, or alternatively `docker compose up -d` to start the bot in the background.


### PR DESCRIPTION
# What does this PR do?

This PR adds a new Github Actions workflow that builds and publishes a multi-platform container image every time a new release is published.

It looks like there was a previous attempt to do this in #133 but its been stale since 2023 so I'm picking this up again in a new PR. I've deviated a bit from that previous PR, primarily that this PR doesn't have an Entrypoint script which sets up a config.json file from environment variables.

---

# Why?

I currently host my 7DTD server on a Kubernetes cluster using https://github.com/vinanrra/Docker-7DaysToDie to manage my dedicated server. I'd love to be able to use this bot to send messages to my discord server but find it hard to set it up alongside my server when it doesn't have a container image that I can run.

![{5F7F7685-25BF-46FB-A9AF-D607F2A28CC5}](https://github.com/user-attachments/assets/07299419-6b08-4096-b770-545647c89e9c)



---

Closes #133 